### PR TITLE
Add german Bban validator

### DIFF
--- a/src/Bban/GermanyBban.php
+++ b/src/Bban/GermanyBban.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace IbanGenerator\Bban;
+
+use InvalidArgumentException;
+
+class GermanyBban implements BbanInterface
+{
+    /**
+     * @var string
+     */
+    private $bankCode;
+
+    /**
+     * @var string
+     */
+    private $accountNumber;
+
+    /**
+     * GermanyBban constructor.
+     *
+     * @param string $bankCode
+     * @param string $accountNumber
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct(
+        $bankCode,
+        $accountNumber
+    ) {
+        self::validateBankCodeFormat($bankCode);
+        self::validateAccountNumberFormat($accountNumber);
+
+        $this->bankCode = $bankCode;
+        $this->accountNumber = $accountNumber;
+    }
+
+    /**
+     * @param string $bban
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return static
+     */
+    public static function fromString($bban)
+    {
+        $bban = preg_replace('/[^0-9a-zA-Z]+/', '', $bban);
+
+        if (! preg_match('/^[\d]{18}$/', $bban)) {
+            throw new InvalidArgumentException('Bban should be 18 numbers');
+        }
+
+        $bankCode = substr($bban, 0, 8);
+        $accountNumber = substr($bban, 8, 10);
+
+        return new static($bankCode, $accountNumber);
+    }
+
+    /**
+     * @return string
+     */
+    public function bankCode()
+    {
+        return $this->bankCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function branchCode()
+    {
+        return '';
+    }
+
+    /**
+     * @return string
+     */
+    public function checkDigits()
+    {
+        return '';
+    }
+
+    /**
+     * @return string
+     */
+    public function accountNumber()
+    {
+        return $this->accountNumber;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->bankCode . $this->accountNumber;
+    }
+
+    /**
+     * @param $bankCode
+     *
+     * @throws InvalidArgumentException
+     */
+    private static function validateBankCodeFormat($bankCode)
+    {
+        if (! preg_match('/^[\d]{8}$/', $bankCode)) {
+            throw new InvalidArgumentException('Bank code should be 8 numbers');
+        }
+    }
+
+    /**
+     * @param $accountNumber
+     *
+     * @throws InvalidArgumentException
+     */
+    private static function validateAccountNumberFormat($accountNumber)
+    {
+        if (! preg_match('/^[\d]{10}$/', $accountNumber)) {
+            throw new InvalidArgumentException('Account number should be 10 numbers');
+        }
+    }
+}

--- a/src/Iban.php
+++ b/src/Iban.php
@@ -28,6 +28,7 @@ class Iban
     private static $countriesSupported = [
         'ES' => Bban\SpainBban::class,
         'AD' => Bban\AndorraBban::class,
+        'DE' => Bban\GermanyBban::class,
     ];
 
     /**

--- a/tests/Bban/GermanyBbanTest.php
+++ b/tests/Bban/GermanyBbanTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace IbanGenerator\Tests\Bban;
+
+use IbanGenerator\Bban\GermanyBban;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class GermanyBbanTest extends TestCase
+{
+    /**
+     * @dataProvider invalidBankCodes
+     *
+     * @expectedException InvalidArgumentException
+     *
+     * @param string $bankCode
+     * @param string $bankAccount
+     */
+    public function testBankCodeShouldBe8NumericDigits(
+        $bankCode,
+        $bankAccount
+    ) {
+        new GermanyBban($bankCode, $bankAccount);
+    }
+
+    /**
+     * @dataProvider invalidBankAccounts
+     *
+     * @expectedException InvalidArgumentException
+     *
+     * @param string $bankCode
+     * @param string $bankAccount
+     */
+    public function testBankAccountShouldBe10NumericDigits(
+        $bankCode,
+        $bankAccount
+    ) {
+        new GermanyBban($bankCode, $bankAccount);
+    }
+
+    /**
+     * @dataProvider validGermanBbans
+     *
+     * @param string $bankCode
+     * @param string $branchCode
+     * @param string $controlDigits
+     * @param string $bankAccount
+     */
+    public function testGetters(
+        $bankCode,
+        $branchCode,
+        $controlDigits,
+        $bankAccount
+    ) {
+        $bban = new GermanyBban(
+            $bankCode,
+            $bankAccount
+        );
+        $this->assertEquals($bankCode, $bban->bankCode());
+        $this->assertEquals($branchCode, $bban->branchCode());
+        $this->assertEquals($controlDigits, $bban->checkDigits());
+        $this->assertEquals($bankAccount, $bban->accountNumber());
+    }
+
+    /**
+     * @dataProvider validGermanBbans
+     *
+     * @param string $bankCode
+     * @param string $branchCode
+     * @param string $controlDigits
+     * @param string $bankAccount
+     */
+    public function testCreateFromStringWithValidAccountShouldReturnGermanyBban(
+        $bankCode,
+        $branchCode,
+        $controlDigits,
+        $bankAccount
+    ) {
+        $bbanString = $bankCode . $branchCode . $controlDigits . $bankAccount;
+        $bban = GermanyBban::fromString($bbanString);
+        $this->assertEquals($bankCode, $bban->bankCode());
+        $this->assertEquals($branchCode, $bban->branchCode());
+        $this->assertEquals($controlDigits, $bban->checkDigits());
+        $this->assertEquals($bankAccount, $bban->accountNumber());
+        $this->assertEquals(strval($bban), $bbanString);
+    }
+
+    /**
+     * @return array
+     */
+    public function invalidBankCodes()
+    {
+        return [
+            ['', '6545', '21', '8754292156'],
+            ['1', '6248', '24', '7851235423'],
+            ['13521', '8723', '12', '2165487232'],
+            ['A445', '2354', '52', '8753245682'],
+        ];
+    }
+
+    /*
+    /**
+     * @return array
+     */
+    public function invalidBankAccounts()
+    {
+        return [
+            ['1232', '2135', '21', ''],
+            ['1234', '4654', '24', '785123'],
+            ['1234', '8795', '12', '21654872324654'],
+            ['1234', '2154', '52', '875A2456J2'],
+        ];
+    }
+
+    /***
+     * @return array
+     */
+    public function validGermanBbans()
+    {
+        return [
+            ['50010517', '', '', '5425194396'],
+            ['50010517', '', '', '9753548973'],
+            ['50010517', '', '', '5739216414'],
+            ['50010517', '', '', '4966436663'],
+        ];
+    }
+
+    /***
+     * @return array
+     */
+    public function invalidBankStrings()
+    {
+        return [
+            ['2085206664030008280'],
+            ['004923520724142054185'],
+            ['210004184A0200051332'],
+        ];
+    }
+}

--- a/tests/IbanTest.php
+++ b/tests/IbanTest.php
@@ -96,7 +96,7 @@ class IbanTest extends TestCase
             $bankAccount
         );
 
-        $iban = Iban::fromBbanAndCountry($bban, 'ES');
+        $iban = Iban::fromBbanAndCountry($bban, strtoupper($countryCode));
         $this->assertEquals($ibanChecksum, $iban->ibanCheckDigits());
     }
 
@@ -248,6 +248,7 @@ class IbanTest extends TestCase
         return [
             ['ES', '00', '3841', '2436', '11', '6183191503'],
             ['ES', '89', '0989', '5990', '44', '6462241825'],
+            ['DE', '03', '50010517', '', '', '9367994767'],
         ];
     }
 
@@ -269,6 +270,7 @@ class IbanTest extends TestCase
             ['ES', '57', '2100', '3063', '99', '2200110010'],
             ['ES', '53', '1491', '0001', '28', '1008158220'],
             ['ES', '27', '2095', '0264', '60', '9105878176'],
+            ['DE', '02', '50010517', '', '', '9367994767'],
         ];
     }
 
@@ -302,6 +304,9 @@ class IbanTest extends TestCase
      *
      * @return BbanInterface
      */
+    // CHAAAANGE utilitzar:
+    // utilitzar Iban::fromString(aqui tot l'iban)
+    //private function prophesizeBban($stringIban)
     private function prophesizeBban(
         $bankCode,
         $branchCode,
@@ -314,6 +319,7 @@ class IbanTest extends TestCase
         $bban = $this->prophesize('IbanGenerator\Bban\BbanInterface');
         $bban->bankCode()->willReturn($bankCode);
         $bban->branchCode()->willReturn($branchCode);
+        // check digits és el checksum o els control digits del bank espanyol?
         $bban->checkDigits()->willReturn($controlDigits);
         $bban->accountNumber()->willReturn($bankAccount);
         $bban->__toString()


### PR DESCRIPTION
Add german IBAN / Bban validator.

It is shorter than the spanish IBAN / Bban, and it does not contain the branch digits or the digits to check the bank account.
It is a first version and I would like to add any functionality that you consider necessary.